### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,7 @@
 Add `@vexip-ui/nuxt` dependency to your project:
 
 ```sh
-# Using pnpm
-pnpm i -D @vexip-ui/nuxt
-
-# Using yarn
-yarn add -D @vexip-ui/nuxt
+npx nuxi@latest module add vexip-ui
 ```
 
 If you want to control the version of Vexip UI, you need to add `vexip-ui` dependency to your project too:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/vexip-ui/vexip-ui/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


### Linked Issues
<!-- Fix #123. Fix #666. -->

### Additional Context
<!-- Any other context or screenshots about the PR here. -->
